### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/node-api/app.js
+++ b/node-api/app.js
@@ -121,7 +121,7 @@ app.all("/api/handleShopperRedirect", async (req, res) => {
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook notification: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response 202
 app.post("/api/webhooks/notifications", async (req, res) => {
 
   console.log("/api/webhooks/notifications");
@@ -148,10 +148,10 @@ app.post("/api/webhooks/notifications", async (req, res) => {
     consumeEvent(notification);
 
     // acknowledge event has been consumed
-    res.send('[accepted]')
+    res.status(202).send(); // Send a 202 response with an empty body
 
   } else {
-    // invalid hmac: do not send [accepted] response
+    // invalid hmac
     console.log("Invalid HMAC signature: " + notification);
     res.status(401).send('Invalid HMAC signature');
   }


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code 202 and an empty response body.

This PR updates all webhook handlers to implement the new approach.