### PR TITLE
Upgrade to iDEAL 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         # cache: 'npm'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
     - run: npm run build --if-present
       working-directory: checkout
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         # cache: 'npm'

--- a/checkout/package.json
+++ b/checkout/package.json
@@ -14,7 +14,7 @@
   },
   "private": true,
   "dependencies": {
-    "@adyen/adyen-web": "5.60.0",
+    "@adyen/adyen-web": "5.68.0",
     "@angular/animations": "~18.2.2",
     "@angular/common": "~18.2.2",
     "@angular/compiler": "~18.2.2",


### PR DESCRIPTION
Support iDEAL 2.0.

Changes required: update to `Drop-in v5.68.0`

### Note 

- on **TEST** the iDEAL payment method in the Customer Area must be updated to use the `AdyenIdeal` acquirer
- on **LIVE** no changes are required in the Customer Area